### PR TITLE
Update rtorrent.auto.install-2.1.1-Debian-Wheezy

### DIFF
--- a/rtorrent.auto.install-2.1.1-Debian-Wheezy
+++ b/rtorrent.auto.install-2.1.1-Debian-Wheezy
@@ -713,7 +713,7 @@ cat > /etc/apache2/sites-available/rutorrent << EOF
 
 	SCGIMount /RPC2 127.0.0.1:5000
 
-	<location /RPC2>
+	<location /rutorrent>
 		AuthName "Tits or GTFO"
 		AuthType Basic
 		Require Valid-User


### PR DESCRIPTION
Changing "location /RPC2" to "location /rutorrent" otherwise the webinterface will immediately load ruTorrent without asking a password.