### PR TITLE
Minor change in rutorrent virtualhost

### DIFF
--- a/rtorrent.auto.install-2.1.1-Ubuntu-14.04
+++ b/rtorrent.auto.install-2.1.1-Ubuntu-14.04
@@ -720,7 +720,7 @@ cat > /etc/apache2/sites-available/rutorrent.conf << EOF
 
 	SCGIMount /RPC2 127.0.0.1:5000
 
-	<Location /rutorrent>
+	<Location /RPC2>
 		AuthName "Tits or GTFO"
 		AuthType Basic
 		Require valid-user


### PR DESCRIPTION
Putting the "/RPC2" back, instead of "/rutorrent"