### PR TITLE
No need to disable 000-default anymore

### DIFF
--- a/rtorrent.auto.install-2.1.1-Ubuntu-14.04
+++ b/rtorrent.auto.install-2.1.1-Ubuntu-14.04
@@ -700,8 +700,11 @@ if ! grep --quiet "^Listen 80$" /etc/apache2/ports.conf; then
 	echo "Listen 80" >> /etc/apache2/ports.conf;
 fi
 
-# Disabling default Apache2 virtualhost
-a2dissite 000-default.conf
+# Adding ServerName localhost to apache2.conf to make the authentication work
+
+if ! grep --quiet "^ServerName localhost$" /etc/apache2/apache2.conf; then
+	echo "ServerName localhost" >> /etc/apache2/apache2.conf;
+fi
 
 # Creating Apache virtual host
 


### PR DESCRIPTION
First, to make the authentication work I had to disable the 000-default vhost. I don't know why, but it seemed that Apache2 didn't want to read the rutorrent vhost and read the 000-default vhost instead. So to force apache2 to read the rutorrent vhost, I had to disable the 000-default vhost.
But then I noticied that I just had to add "ServerName localhost" in apache2.conf to make the authentication work, without disabling the 000-default vhost and removing httprpc and/or rpc plugin.
See: https://github.com/Kerwood/rtorrent.auto.install/issues/30
So if ServerName localhost isn't present in the apache2 conf, ruTorrent will load the dashboard without prompting username and password first.
I made this little change in the script to make the script 100% fully functional without asking the user to touch the configuration to make the authentication work.