### PR TITLE
Updated GeoIP dependencies

### DIFF
--- a/rtorrent.auto.install-2.1.1-Debian-Wheezy
+++ b/rtorrent.auto.install-2.1.1-Debian-Wheezy
@@ -353,6 +353,10 @@ case $plugin in
 	desc="http://code.google.com/p/rutorrent/wiki/PluginGeoIP"
 	unpack="tar -zxvf $file -C $plugindir"
 	fu_download
+	wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
+	gunzip GeoLiteCity.dat.gz
+	mkdir -v /usr/share/GeoIP
+	mv -v GeoLiteCity.dat /usr/share/GeoIP/GeoIPCity.dat
 	apt-get install php5-geoip
 	;;
 


### PR DESCRIPTION
If you only install "php5-geoip" it won't be enough to make the GeoIP plugin shows the clients countries and flags. So the plugin won't really work as expected.
Source: http://terminal28.com/how-to-install-and-configure-rutorrent-rtorrent-libtorrent-xmlrpc-screen-debian-7-wheezy/#84_Install_GeoIP_i_ffmpeg