### PR TITLE
Update rtorrent-init

### DIFF
--- a/Files/rtorrent-init
+++ b/Files/rtorrent-init
@@ -138,7 +138,7 @@ echo "."
 restart|force-reload)
 echo -n "Restarting $DESC: $NAME"
 d_stop
-sleep 1
+sleep 5
 d_start
 echo "."
 ;;


### PR DESCRIPTION
1 second of sleeping isn't enough when you have a rTorrent instance with a lot of torrents. Give at least 5 second for rTorrent to stop/start.
I have a lot of torrents and when I use the inital rtorrent-init with 1 sec of sleep, rTorrent only stop, and doesn't start again because 1 sec is too short for rTorrent to properlly stop all torrents and then start again.