### PR TITLE
libcrypto is now needed

### DIFF
--- a/Rtorrent-Auto-Install-3.0.2-Debian-Wheezy
+++ b/Rtorrent-Auto-Install-3.0.2-Debian-Wheezy
@@ -717,7 +717,7 @@ function SELECT_PLUGINS {
 # Function for installing dependencies
 function APT-DEPENDENCIES {
 	apt-get update
-	apt-get -y install openssl git subversion apache2 apache2-utils build-essential libsigc++-2.0-dev libcurl4-openssl-dev automake libtool libcppunit-dev libncurses5-dev libapache2-mod-scgi php5 php5-curl php5-cli libapache2-mod-php5 screen unrar-free unzip
+	apt-get -y install openssl git subversion apache2 apache2-utils build-essential libsigc++-2.0-dev libcurl4-openssl-dev automake libtool libcppunit-dev libncurses5-dev libapache2-mod-scgi php5 php5-curl php5-cli libapache2-mod-php5 screen unrar-free unzip libssl-dev
 }
 
 # Function for setting up xmlrpc, libtorrent and rtorrent


### PR DESCRIPTION
During the make process of libtorrent or rtorrent, libcrypto is needed. I fixed this by installing libssl-dev. I used the latest version by cloning libtorrent and rtorrent directy from their git repo, so it might be new.