### PR TITLE
Create Rtorrent-Auto-Install-3.0.2-Raspbian-Wheezy

### DIFF
--- a/Rtorrent-Auto-Install-3.0.2-Raspbian-Wheezy
+++ b/Rtorrent-Auto-Install-3.0.2-Raspbian-Wheezy
@@ -1,0 +1,930 @@
+#!/bin/bash
+# PLEASE DO NOT SET ANY OF THE VARIABLES, THEY WILL BE POPULATED IN THE MENU
+clear
+
+# Formatting variables
+BOLD=$(tput bold)
+NORMAL=$(tput sgr0)
+GREEN=$(tput setaf 2)
+LBLUE=$(tput setaf 6)
+RED=$(tput setaf 1)
+PURPLE=$(tput setaf 5)
+
+# The system user rtorrent is going to run as
+RTORRENT_USER=""
+
+# The user that is going to log into rutorrent (htaccess)
+WEB_USER=""
+
+# Array with webusers including their hashed paswords
+WEB_USER_ARRAY=()
+
+# Temporary download folder for plugins
+TEMP_PLUGIN_DIR="/tmp/rutorrentPlugins"
+
+# Array of downloaded plugins
+PLUGIN_ARRAY=()
+
+#rTorrent users home dir.
+HOMEDIR=""
+
+# Function to check if running user is root
+function CHECK_ROOT {
+	if [ "$(id -u)" != "0" ]; then
+		echo
+		echo "This script must be run as root." 1>&2
+		echo
+		exit 1
+	fi
+}
+
+# Checks is apache2-utils is installed. Its is needed to make the Web user
+function APACHE-UTILS {
+	dpkg -s apache2-utils > /dev/null 2>&1
+
+	if [ $? != 0 ]; then
+		echo
+		echo " The package apache2-utils is not installed and is needed to continue."
+		read -p " Do you want to install it? [y/n]: " -n 1
+		if [[ $REPLY =~ [Yy]$ ]]; then
+			echo
+			apt-get update
+			apt-get -y install apache2-utils
+			clear
+		else
+			clear
+			exit
+		fi
+	fi
+}
+
+# License
+function LICENSE {
+	clear
+	echo "${BOLD}--------------------------------------------------------------------------------"
+	echo " THE BEER-WARE LICENSE (Revision 42):"
+	echo " <patrick@kerwood.dk> wrote this script. As long as you retain this notice you"
+	echo " can do whatever you want with this stuff. If we meet some day, and you think"
+	echo " this stuff is worth it, you can buy me a beer in return."
+	echo
+	echo " - ${LBLUE}Patrick Kerwood @ LinuxBloggen.dk${NORMAL}"
+	echo "${BOLD}--------------------------------------------------------------------------------${NORMAL}"
+	echo
+	read -p " Press any key to continue..." -n 1
+	echo
+}
+
+# Function to set the system user, rtorrent is going to run as
+function SET_RTORRENT_USER {
+	con=0
+	while [ $con -eq 0 ]; do
+		echo -n "Please type a valid system user: "
+		read RTORRENT_USER
+
+		if [ -z $(cat /etc/passwd | grep "^$RTORRENT_USER:") ]; then
+			echo
+			echo "This user does not exist!"
+		elif [ $(cat /etc/passwd | grep "^$RTORRENT_USER:" | cut -d: -f3) -lt 999 ]; then
+			echo
+			echo "That user's UID is too low!"
+		elif [ $RTORRENT_USER == nobody ]; then
+			echo
+			echo "You cant use 'nobody' as user!"
+		else
+			HOMEDIR=$(cat /etc/passwd | grep "$RTORRENT_USER": | cut -d: -f6)
+			con=1
+		fi
+	done
+}
+
+# Function to  create users for the webinterface
+function SET_WEB_USER {
+	while true; do
+		echo -n "Please type the username for the webinterface, system user not required: "
+		read WEB_USER
+		USER=$(htpasswd -n $WEB_USER 2>/dev/null)
+		if [ $? = 0 ]; then
+			WEB_USER_ARRAY+=($USER)
+			break
+		else
+			echo
+			echo "${RED}Something went wrong!"
+			echo "You have entered an unusable username and/or different passwords.${NORMAL}"
+			echo
+		fi
+	done
+}
+
+# Function to list WebUI users in the menu
+function LIST_WEB_USERS {
+	for i in ${WEB_USER_ARRAY[@]}; do
+		USER_CUT=$(echo $i | cut -d \: -f 1)
+		echo -n "$USER_CUT"
+		echo
+	done
+}
+
+# Function to list plugins, downloaded, in the menu
+function LIST_PLUGINS {
+	if [ ${#PLUGIN_ARRAY[@]} -eq 0 ]; then
+		echo "   No plugins downloaded!"
+	else
+		for i in "${PLUGIN_ARRAY[@]}"; do
+			echo "   - $i"
+		done
+	fi
+}
+
+# RaspberryPi Ascii Art taken from piksel on github, https://gist.github.com/piksel/3023588
+# Header for the menu
+function HEADER {
+	clear
+	echo "${GREEN}
+       .~~.   .~~.
+      '. \ ' ' / .'    ${NORMAL}                   _                          _ ${RED}
+       .~ .~~~..~.     ${NORMAL}   ___ ___ ___ ___| |_ ___ ___ ___ _ _    ___|_|${RED}
+      : .~.'~'.~. :    ${NORMAL}  |  _| .'|_ -| . | . | -_|  _|  _| | |  | . | |${RED}
+     ~ (   ) (   ) ~   ${NORMAL}  |_| |__,|___|  _|___|___|_| |_| |_  |  |  _|_|${RED}
+    ( : '~'.~.'~' : )  ${NORMAL}              |_|                 |___|  |_|    ${RED}
+     ~ .~ (   ) ~. ~
+      (  : '~' :  )       ${NORMAL}${BOLD}Apache2 + rTorrent + ruTorrent Auto Install${NORMAL}${RED}
+       '~ .~~~. ~'            ${NORMAL}${LBLUE} Patrick Kerwood @ LinuxBloggen.dk${NORMAL}${RED}
+           '~'${NORMAL}"
+	echo "${BOLD}--------------------------------------------------------------------------------${NORMAL}"
+	echo
+}
+
+# Function for the Plugins download part
+function DOWNLOAD_PLUGIN {
+	echo
+	echo -e "$desc"
+	echo
+	read -p "Download ${LBLUE}$name${NORMAL} [y/n]: " -n 1
+
+	if [[ $REPLY =~ [Yy]$ ]]; then
+		echo
+		wget "$url"
+		$unpack
+		if [ $? -eq "0" ]; then
+			rm "$file"
+			echo
+			PLUGIN_ARRAY+=("${name}")
+			error1="${GREEN}${BOLD}$name${NORMAL}${GREEN} downloaded, unpacked and moved to temporary plugins folder${NORMAL}"
+			echo
+		else
+			echo
+			error1="${RED}Error! Something went wrong...${NORMAL}"
+		fi
+	elif [[ $REPLY =~ [Nn]$ ]]; then
+		echo
+		read -p " Press any key to return to the list..." -n 1
+		SELECT_PLUGINS
+	fi
+	echo
+}
+
+function SELECT_PLUGINS {
+	if [ ! -d $TEMP_PLUGIN_DIR ]; then
+		mkdir $TEMP_PLUGIN_DIR
+	fi
+
+	clear
+
+	while true
+	do
+		echo
+		echo "${GREEN}--------------------------------------------------------------------------------${NORMAL}"
+		echo
+		echo "1 - Erase Data ${GREEN}[Reccomended]${NORMAL}"
+		echo "2 - Create v3.6"
+		echo "3 - Traffic v3.6"
+		echo "4 - RSS v3.6"
+		echo "5 - Edit v3.6"
+		echo "6 - Retrackers v3.6"
+		echo "7 - Throttle v3.6"
+		echo "8 - Cookies v3.6"
+		echo "9 - Scheduler v3.6"
+		echo "10 - Auto Tools v3.6"
+		echo "11 - Data Dir v3.6 ${GREEN}[Reccomended]${NORMAL}"
+		echo "12 - Track Lables v3.6 ${GREEN}[Reccomended]${NORMAL}"
+		echo "13 - Geo IP v3.6"
+		echo "14 - Ratio v3.6 ${GREEN}[Reccomended]${NORMAL}"
+		echo "15 - Show Peers like wTorrent v3.6"
+		echo "16 - Seeding Time v3.6 ${GREEN}[Reccomended]${NORMAL}"
+		echo "17 - HTTPRPC v3.6"
+		echo "18 - Diskspace v3.6"
+		echo "19 - Unpack v3.6"
+		echo "20 - Get Dir v3.6"
+		echo "21 - Source v3.6"
+		echo "22 - Chunks v3.6"
+		echo "23 - Data v3.6"
+		echo "24 - CPU Load v3.6"
+		echo "25 - Extsearch v3.6"
+		echo "26 - Theme v3.6"
+		echo "27 - Login Mgr v3.6"
+		echo "28 - ruTorrent Label Management Suite v1.1 ${GREEN}[Reccomended]${NORMAL}"
+		echo "29 - NFO ${GREEN}[Reccomended]${NORMAL}"
+		echo "30 - Chat v2.0"
+		echo "31 - Logoff v1.3"
+		echo "32 - Pause v1.2"
+		echo "33 - Instant Search v1.0"
+		echo "34 - File Drop v3.6 (FF > 3.6 & Chrome only)"
+		echo "35 - Check Port v3.6"
+		echo "36 - History v3.6"
+		echo "37 - iPad v3.6"
+		echo "38 - Extended Ratio v3.6"
+		echo "39 - Feeds v3.6"
+		echo "40 - Media Information v3.6"
+		echo "41 - RSS URL Rewrite v3.6"
+		echo "42 - Screenshot v3.6"
+		echo "43 - RPC v3.6"
+		echo "44 - Rutracker Check v3.6"
+		echo "45 - Noty v3.6"
+		echo "46 - Task v3.6"
+		echo "47 - All Plugins v3.6. More at https://github.com/Novik/ruTorrent/wiki/Plugins"
+		echo
+		echo "0 - Exit plugin installation"
+		echo
+		echo "${GREEN}--------------------------------------------------------------------------------${NORMAL}"
+		echo -e $error1
+		unset error1
+		echo -n "Choose plugin to see info: "
+
+		read -e plugin
+
+		case $plugin in
+
+			1)
+			name="Erase Data v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/erasedata-3.6.tar.gz"
+			file="erasedata-3.6.tar.gz"
+			desc=" This plugin adds a context menu item to the right click menu which allows you to delete data. \n http://code.google.com/p/rutorrent/wiki/PluginErasedata"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			2)
+			name="Create v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/create-3.6.tar.gz"
+			file="create-3.6.tar.gz"
+			desc="This plugin allows for the creation of new .torrent files from a file or directory full of files.\nhttp://code.google.com/p/rutorrent/wiki/PluginCreate"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			3)
+			name="Trafic v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/trafic-3.6.tar.gz"
+			file="trafic-3.6.tar.gz"
+			desc="The Trafic plugin is a subsystem for monitoring rtorrent traffic totals.\nIt tracks both system wide and per-tracker totals.\nThe plugin can display totals in three formats, hourly, daily, and mouthly.\nStatistics can be cleaned out at any time by clicking the 'Clear' button on the interface (see screenshot).\nhttp://code.google.com/p/rutorrent/wiki/PluginTrafic"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			4)
+			name="RSS v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/rss-3.6.tar.gz"
+			file="rss-3.6.tar.gz"
+			desc="This plugin is designed to fetch torrents via rss download links.\nIt has 2 main parts, one for entering feeds, the other for setting up filters.\nFor more information about rss, see http://en.wikipedia.org/wiki/RSS.\nhttp://code.google.com/p/rutorrent/wiki/PluginRSS"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			apt-get -y install curl
+			;;
+
+			5)
+			name="Edit v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/edit-3.6.tar.gz"
+			file="edit-3.6.tar.gz"
+			desc="This plugin allows you to edit the list of trackers, and change the comment of the current torrent.\nAfter installation, a new context menu item will become available when you right click a torrent from the list, 'Edit Torrent...'\nSelecting this will open the 'Torrent Properties' menu.\nhttp://code.google.com/p/rutorrent/wiki/PluginEdit"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			6)
+			name="Retrackers v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/retrackers-3.6.tar.gz"
+			file="retrackers-3.6.tar.gz"
+			desc="This plug-in appends specified trackers to the trackers list of all newly added torrents.\nBy the way, torrents may be added by any way - not just via ruTorrent.\nhttp://code.google.com/p/rutorrent/wiki/PluginRetrackers"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			7)
+			name="Throttle v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/throttle-3.6.tar.gz"
+			file="throttle-3.6.tar.gz"
+			desc="In rTorrent version 0.8.5 and later it is possible to set limits of speed for groups of torrents.\nThrottle plug-in gives a convenient control over this possibility.\nAfter this plug-in is installed a new option "Channels" will appear in the Settings dialog.\nSpeed limits for some (by default - 10) channels can be set here.\nAssignment of channel number for a particular torrent or for a group of torrents can be made in it's contextual menu.\nNote - '0'-value, conventionally for rTorrent, means 'no limits', but not 'stop torrent'.\nSo the lowest possible limit is 1 Kbps.\nhttp://code.google.com/p/rutorrent/wiki/PluginThrottle"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			8)
+			name="Cookies v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/cookies-3.6.tar.gz"
+			file="cookies-3.6.tar.gz"
+			desc="Some trackers use cookies for the client authentication.\nIt is transparent to user who uses a browser to work with such servers - browser store these cookies and returns them to the server automatically.\nThe user just needs to enter login/password from time to time.\nBut when rTorrent is used to work with such trackers (e.g. adding a torrent via URL) it might be a problem because rTorrent does not understand cookies.\nSo the the information from cookies should be provided for rTorrent separately.\nhttp://code.google.com/p/rutorrent/wiki/PluginCookies"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			9)
+			name="Scheduler v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/scheduler-3.6.tar.gz"
+			file="scheduler-3.6.tar.gz"
+			desc="http://code.google.com/p/rutorrent/wiki/PluginScheduler"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			10)
+			name="Auto Tools v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/autotools-3.6.tar.gz"
+			file="autotools-3.6.tar.gz"
+			desc="The plug-in provides some possibilities on automation. Following functions are realized for now:\nAuto Label automatic creation of labels at addition of new torrent through the web interface.\nAuto Move automatic transferring of torrent data files to other directory on downloading completion.\nAuto Watch automatic adding torrents to rtorrent via nested set of watch directories.\nhttp://code.google.com/p/rutorrent/wiki/PluginAutotools"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			11)
+			name="Data Dir v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/datadir-3.6.tar.gz"
+			file="datadir-3.6.tar.gz"
+			desc="The plug-in is intended for replacement of the current torrent data directory on another.\nSuch operation is required, for example, if the torrent data directory has been moved manually.\nIt is also possible to move downloaded torrent's data.\nAfter plug-in installation there will be a new item 'Save to...' in the context menu of the downloading area which shows a dialogue 'Torrent data directory'.\nIn this dialogue you can specify a new path to the torrent data.\nhttp://code.google.com/p/rutorrent/wiki/PluginDataDir"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			12)
+			name="Track Lables v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/tracklabels-3.6.tar.gz"
+			file="tracklabels-3.6.tar.gz"
+			desc="The plug-in adds a set of labels on the category panel.\nThese labels are created automatically on the basis of torrents' trackers.\nhttp://code.google.com/p/rutorrent/wiki/PluginTracklabels"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			13)
+			name="GeoIP v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/geoip-3.6.tar.gz"
+			file="geoip-3.6.tar.gz"
+			desc="http://code.google.com/p/rutorrent/wiki/PluginGeoIP"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			wget http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz
+			mkdir -v /usr/share/GeoIP
+			gunzip GeoLiteCity.dat.gz
+			mv -v GeoLiteCity.dat /usr/share/GeoIP/GeoIPCity.dat
+			rm GeoLiteCity.dat.gz
+			apt-get install php5-geoip
+			;;
+
+			14)
+			name="Ratio v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/ratio-3.6.tar.gz"
+			file="ratio-3.6.tar.gz"
+			desc="Since version 0.8.5 rTorrent has a capability to set ratio limits for groups of torrents.\nThe plug-in allows to manage it conveniently.\nWhen the plug-in is installed a new section 'Ratio groups' appears in the Settings dialog.\nHere user can define limits of ratio for some (by default - 8) groups.\nAssignation of group to one or several torrents is performed by selecting an appropriate option in the context menu of torrents.\nhttp://code.google.com/p/rutorrent/wiki/PluginRatio"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			15)
+			name="Show Peers like wTorrent v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/show_peers_like_wtorrent-3.6.tar.gz"
+			file="show_peers_like_wtorrent-3.6.tar.gz"
+			desc="The plug-in changes the format of values in columns 'Seeds' and 'Peers' in the torrents list.\nhttp://code.google.com/p/rutorrent/wiki/PluginShow_peers_like_wtorrent"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			16)
+			name="Seeding Time v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/seedingtime-3.6.tar.gz"
+			file="seedingtime-3.6.tar.gz"
+			desc="The plug-in adds the columns 'Finished' and 'Added' to the torrents list.\nThis columns contains the time when download of the torrent was completed and, accordingly, the time when torrent was added.\nhttp://code.google.com/p/rutorrent/wiki/PluginSeedingtime"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			17)
+			name="HTTPRPC v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/httprpc-3.6.tar.gz"
+			file="httprpc-3.6.tar.gz"
+			desc="This plugin is designed as a easy to use replacement for the mod_scgi (or similar) webserver module, with emphasis on extremely low bandwidth use.\nIf you install this plugin, you do not need to use mod_scgi or the RPC Plugin.\nNote: This plugin requires a faster server, and is not recommended for embedded systems, like a router or slow computer.\nhttp://code.google.com/p/rutorrent/wiki/PluginHTTPRPC"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			18)
+			name="Diskspace v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/diskspace-3.6.tar.gz"
+			file="diskspace-3.6.tar.gz"
+			desc="This plugin adds an easy to read disk meter to the bottom menu bar.\nhttp://code.google.com/p/rutorrent/wiki/PluginDiskspace"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			19)
+			name="Unpack v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/unpack-3.6.tar.gz"
+			file="unpack-3.6.tar.gz"
+			desc="This plugin is designed to manually or automatically unrar/unzip torrent data.\nhttp://code.google.com/p/rutorrent/wiki/PluginUnpack"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			20)
+			name="Get Dir v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/_getdir-3.6.tar.gz"
+			file="_getdir-3.6.tar.gz"
+			desc="The service plug-in _getdir gives to other plug-ins the possibility of comfortable navigation on a host file system.\nShows only directories to which rtorrent can write and which php can show.\nhttp://code.google.com/p/rutorrent/wiki/Plugin_getdir"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			21)
+			name="Source v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/source-3.6.tar.gz"
+			file="source-3.6.tar.gz"
+			desc="This plugin adds a 'Get .torrent' item to the right click context menu.\nAllowing you to download the original .torrent file from the server, to your local machine.\nhttp://code.google.com/p/rutorrent/wiki/PluginSource"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			22)
+			name="Chunks v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/chunks-3.6.tar.gz"
+			file="chunks-3.6.tar.gz"
+			desc="This plugin adds a new tab to the tab bar called 'chunks'.\nThe added tab allows you to monitor the download status of each individual torrent 'piece'\nhttp://code.google.com/p/rutorrent/wiki/PluginChunks"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			23)
+			name="Data v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/data-3.6.tar.gz"
+			file="data-3.6.tar.gz"
+			desc="This plugin adds the 'Get Data' item to the right click menu.\nThis allows you to download the file in question via http to your local machine.\nOn 32 bit systems, you can not download files larger than 2 GB, this is due to a php limitation\nhttp://code.google.com/p/rutorrent/wiki/PluginData"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			24)
+			name="CPU Load v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/cpuload-3.6.tar.gz"
+			file="cpuload-3.6.tar.gz"
+			desc="This plugin adds a CPU Load usage bar to the bottom toolbar.\nhttp://code.google.com/p/rutorrent/wiki/PluginCpuload"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			25)
+			name="Extsearch v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/extsearch-3.6.tar.gz"
+			file="extsearch-3.6.tar.gz"
+			desc="This plugin adds the ability to search many popular torrent sites for content without leaving the rutorrent url.\nhttp://code.google.com/p/rutorrent/wiki/PluginExtsearch"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			26)
+			name="Theme v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/theme-3.6.tar.gz"
+			file="theme-3.6.tar.gz"
+			desc="This plugin allows you to change the gui theme to one of several provided themes, or any your create,\nprovided they are placed in the proper directory within the plugin.\nhttp://code.google.com/p/rutorrent/wiki/PluginTheme"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			27)
+			name="Login Mgr v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/loginmgr-3.6.tar.gz"
+			file="loginmgr-3.6.tar.gz"
+			desc="This plugin is used to login to 3rd party torrent sites.\nIt's designed to be used in cased where cookies fail.\nIt is a support plugin used for RSS and ExtSearch.\nNOTE: This plugin saves passwords in plain text.\nhttp://code.google.com/p/rutorrent/wiki/PluginLoginMgr"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			28)
+			name="Loot At v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/lookat-3.6.tar.gz"
+			file="lookat-3.6.tar.gz"
+			desc="This plugin is intended for looking torrent's name in the external sources."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			29)
+			name="NFO"
+			url="http://srious.biz/nfo.tar.gz"
+			file="nfo.tar.gz"
+			desc="This plugin shows the contents of the .nfo file for a given torrent.\nhttp://code.google.com/p/rutorrent/wiki/PluginNFO"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			30)
+			name="Chat v2.0"
+			url="http://rutorrent-chat.googlecode.com/files/chat-2.0.tar.gz"
+			file="chat-2.0.tar.gz"
+			desc="This plugin adds a chatbox to multi-user rutorrent installs.\nNOTE: Currently this is a single server chat program only (if you have multiple servers, this will NOT allow your users to chat across them).\nhttp://code.google.com/p/rutorrent/wiki/PluginChat"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			31)
+			name="Logoff v1.3"
+			url="http://rutorrent-logoff.googlecode.com/files/logoff-1.3.tar.gz"
+			file="logoff-1.3.tar.gz"
+			desc="This plugin allows you to switch users or logoff on systems which use authentication.\nhttp://code.google.com/p/rutorrent-logoff/"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			32)
+			name="Pause v1.2"
+			url="http://rutorrent-pausewebui.googlecode.com/files/pausewebui.1.2.zip"
+			file="pausewebui.1.2.zip"
+			desc="Plugin to pause the refresh timer, and add a button to manually refresh the page.\nhttp://code.google.com/p/rutorrent/wiki/PluginPause"
+			unpack="unzip $file -d $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			33)
+			name="Instant Search v1.0"
+			url="http://rutorrent-instantsearch.googlecode.com/files/instantsearch.1.0.zip"
+			file="instantsearch.1.0.zip"
+			desc="This plugin lets you search for local torrents running in rutorrent, updating results as you type them.\nhttp://code.google.com/p/rutorrent/wiki/PluginInstantSearch"
+			unpack="unzip $file -d $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			34)
+			name="File Drop v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/filedrop-3.6.tar.gz"
+			file="filedrop-3.6.tar.gz"
+			desc="This plugin allows users to drag multiple torrents from desktop to the browser (FF > 3.6 & Chrome only)."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			35)
+			name="Check Port v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/check_port-3.6.tar.gz"
+			file="check_port-3.6.tar.gz"
+			desc="This plugin adds an incoming port status indicator to the bottom bar."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			36)
+			name="History v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/history-3.6.tar.gz"
+			file="history-3.6.tar.gz"
+			desc="This plugin is designed to log a history of torrents."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			37)
+			name="iPad Plugin v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/ipad-3.6.tar.gz"
+			file="ipad-3.6.tar.gz"
+			desc="This plugin allows ruTorrent to work properly on iPad-like devices."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			38)
+			name="Extended Ratio v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/extratio-3.6.tar.gz"
+			file="extratio-3.6.tar.gz"
+			desc="This plugin extends the functionality of the ratio plugin."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			39)
+			name="Feeds v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/feeds-3.6.tar.gz"
+			file="feeds-3.6.tar.gz"
+			desc="This plugin is intended for making RSS feeds with information of torrents. \nhttp://code.google.com/p/rutorrent/wiki/PluginFeeds"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			40)
+			name="Media Information v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/mediainfo-3.6.tar.gz"
+			file="mediainfo-3.6.tar.gz"
+			desc="This plugin is intended to display media file information."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			apt-get -y install libzen0 libmediainfo0 mediainfo
+			wget http://dl.bintray.com/novik65/generic/plugins/_task-3.6.tar.gz
+			tar -zxvf _task-3.6.tar.gz -C $TEMP_PLUGIN_DIR
+			rm _task-3.6.tar.gz
+			;;
+
+			41)
+			name="RSS URL Rewrite v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/rssurlrewrite-3.6.tar.gz"
+			file="rssurlrewrite-3.6.tar.gz"
+			desc="This plugin extends the functionality of the RSS plugin. \nhttp://code.google.com/p/rutorrent/wiki/PluginRSSURLRewrite"
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			42)
+			name="Screenshot v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/screenshots-3.6.tar.gz"
+			file="screenshots-3.6.tar.gz"
+			desc="This plugin is intended to show screenshots from video files. Needs the package 'ffmpeg' to work."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			apt-get -y install ffmpeg
+			wget http://dl.bintray.com/novik65/generic/plugins/_task-3.6.tar.gz
+			tar -zxvf _task-3.6.tar.gz -C $TEMP_PLUGIN_DIR
+			rm _task-3.6.tar.gz
+			;;
+
+			43)
+			name="RPC v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/rpc-3.6.tar.gz"
+			file="rpc-3.6.tar.gz"
+			desc="This plugin is a replacement for the mod_scgi webserver module."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			44)
+			name="Rutracker Check v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/rutracker_check-3.6.tar.gz"
+			file="rutracker_check-3.6.tar.gz"
+			desc="This plugin checks the rutracker.org tracker for updated/deleted torrents."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			45)
+			name="Noty v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/_noty-3.6.tar.gz"
+			file="_noty-3.6.tar.gz"
+			desc="This plugin provides the notification functionality for other plugins."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			46)
+			name="Task v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins/_task-3.6.tar.gz"
+			file="_task-3.6.tar.gz"
+			desc="This plugin provides the possibility of running various scripts on the host system."
+			unpack="tar -zxvf $file -C $TEMP_PLUGIN_DIR"
+			DOWNLOAD_PLUGIN
+			;;
+
+			47)
+			name="All Plugins v3.6"
+			url="http://dl.bintray.com/novik65/generic/plugins-3.6.tar.gz"
+			file="plugins-3.6.tar.gz"
+			desc="This plugin installs about 40+ plugins except plugins number 29 to 33 (NFO, Chat, Logoff, Pause and Instant Search). \nMore info at https://github.com/Novik/ruTorrent/wiki/Plugins \nREMEBER TO REMOVE HTTPRPC AND RPC PLUGINS FOR LOGIN TO WORK AT FIRST RUN!"
+			unpack="tar -zxvf $file -C /tmp/"
+			DOWNLOAD_PLUGIN
+			mv /tmp/plugins/* $TEMP_PLUGIN_DIR
+			apt-get -y install php5-geoip ffmpeg curl libzen0 libmediainfo0 mediainfo
+			;;
+
+			0)
+			break
+			;;
+
+			*)
+			echo
+			error1="${RED}Not a usable number..!${NORMAL}"
+			echo
+			;;
+		esac
+	done
+}
+
+# Function for installing dependencies
+function APT-DEPENDENCIES {
+	apt-get update
+	apt-get -y install openssl git subversion apache2 build-essential libsigc++-2.0-dev libcurl4-openssl-dev automake libtool libcppunit-dev libncurses5-dev libapache2-mod-scgi php5 php5-curl php5-cli libapache2-mod-php5 screen unrar-free unzip
+}
+
+# Function for setting up xmlrpc, libtorrent and rtorrent
+function INSTALL_RTORRENT {
+	# Installing xmlrpc-c
+	svn checkout http://svn.code.sf.net/p/xmlrpc-c/code/stable xmlrpc-c
+	cd xmlrpc-c
+	./configure --disable-cplusplus
+	make
+	make install
+	cd ..
+	rm -rv xmlrpc-c
+
+	mkdir rtorrent
+	cd rtorrent
+
+	# Installing libtorrent
+	wget https://github.com/rakshasa/libtorrent/archive/0.13.4.tar.gz -O libtorrent-0.13.4.tar.gz
+	tar -zxvf libtorrent-0.13.4.tar.gz
+	cd libtorrent-0.13.4
+	./autogen.sh
+	./configure
+	make
+	make install
+	cd ..
+
+	# Installing rtorrent
+	wget https://github.com/rakshasa/rtorrent/archive/0.9.4.tar.gz -O rtorrent-0.9.4.tar.gz
+	tar -zxvf rtorrent-0.9.4.tar.gz
+	cd rtorrent-0.9.4
+	./autogen.sh
+	./configure --with-xmlrpc-c
+	make
+	make install
+	cd ../..
+	rm -rv rtorrent
+
+	ldconfig
+
+	# Creating session directory
+	if [ ! -d "$HOMEDIR"/.rtorrent-session ]; then
+		mkdir "$HOMEDIR"/.rtorrent-session
+		chown "$RTORRENT_USER"."$RTORRENT_USER" "$HOMEDIR"/.rtorrent-session
+	else
+		chown "$RTORRENT_USER"."$RTORRENT_USER" "$HOMEDIR"/.rtorrent-session
+	fi
+
+	# Creating downloads folder
+	if [ ! -d "$HOMEDIR"/Downloads ]; then
+		mkdir "$HOMEDIR"/Downloads
+		chown "$RTORRENT_USER"."$RTORRENT_USER" "$HOMEDIR"/Downloads
+	else
+		chown "$RTORRENT_USER"."$RTORRENT_USER" "$HOMEDIR"/Downloads
+	fi
+
+	# Downloading rtorrent.rc file.
+	wget -O $HOMEDIR/.rtorrent.rc https://raw.github.com/Kerwood/rtorrent.auto.install/master/Files/rtorrent.rc
+	chown "$RTORRENT_USER"."$RTORRENT_USER" $HOMEDIR/.rtorrent.rc
+	sed -i "s@HOMEDIRHERE@$HOMEDIR@g" $HOMEDIR/.rtorrent.rc
+}
+
+# Function for installing rutorrent and plugins
+function INSTALL_RUTORRENT {
+	# Installing rutorrent.
+	wget http://dl.bintray.com/novik65/generic/rutorrent-3.6.tar.gz
+	tar -zxvf rutorrent-3.6.tar.gz
+
+	if [ -d /var/www/rutorrent ]; then
+		rm -r /var/www/rutorrent
+	fi
+
+	# Changeing SCGI mount point in rutorrent config.
+	sed -i "s/\/RPC2/\/rutorrent\/RPC2/g" ./rutorrent/conf/config.php
+
+	mv -f rutorrent /var/www/
+	rm -v rutorrent-3.6.tar.gz
+
+	mv -fv "$TEMP_PLUGIN_DIR"/* /var/www/rutorrent/plugins
+
+	# Changing permissions for rutorrent and plugins.
+	chown -R www-data.www-data /var/www/rutorrent
+	chmod -R 775 /var/www/rutorrent
+}
+
+# Function for configuring apache
+function CONFIGURE_APACHE {
+	# Creating symlink for scgi.load
+	if [ ! -h /etc/apache2/mods-enabled/scgi.load ]; then
+		ln -s /etc/apache2/mods-available/scgi.load /etc/apache2/mods-enabled/scgi.load
+	fi
+
+	# Check if apache2 has port 80 enabled
+	if ! grep --quiet "^Listen 80$" /etc/apache2/ports.conf; then
+		echo "Listen 80" >> /etc/apache2/ports.conf;
+	fi
+
+	# Adding ServerName localhost to apache2.conf
+	if ! grep --quiet "^ServerName$" /etc/apache2/apache2.conf; then
+		echo "ServerName localhost" >> /etc/apache2/apache2.conf;
+	fi
+
+	# Creating Apache virtual host
+	if [ ! -f /etc/apache2/sites-available/rutorrent.conf ]; then
+
+		cat > /etc/apache2/sites-available/rutorrent.conf << EOF
+<VirtualHost *:80>
+	ServerAlias *
+	DocumentRoot /var/www/
+	CustomLog /var/log/apache2/rutorrent.log vhost_combined
+	ErrorLog /var/log/apache2/rutorrent_error.log
+	SCGIMount /rutorrent/RPC2 127.0.0.1:5000
+
+	<Directory "/var/www/rutorrent">
+		AuthName "Tits or GTFO"
+		AuthType Basic
+		Require valid-user
+		AuthUserFile /var/www/rutorrent/.htpasswd
+	</Directory>
+</VirtualHost>
+EOF
+
+		a2ensite rutorrent.conf
+		service apache2 restart
+	fi
+
+	# Creating .htaccess file
+	printf "%s\n" "${WEB_USER_ARRAY[@]}" > /var/www/rutorrent/.htpasswd
+}
+
+# Function for setting up the init script.
+function SETUP_INIT {
+	# Downloading and installing rtorrent init script.
+	wget -O /etc/init.d/rtorrent-init https://raw.github.com/Kerwood/rtorrent.auto.install/master/Files/rtorrent-init
+	chmod +x /etc/init.d/rtorrent-init
+	sed -i "s/USERNAMEHERE/$RTORRENT_USER/g" /etc/init.d/rtorrent-init
+	update-rc.d rtorrent-init defaults
+	service rtorrent-init start
+}
+
+# Function for showing the end result when install is complete.
+function INSTALL_COMPLETE {
+	rm -r $TEMP_PLUGIN_DIR
+
+	HEADER
+
+	echo "${GREEN}Installation is complete..${NORMAL}"
+	echo
+	echo "${PURPLE}Your downloads is put in the 'Downloads' folder, sessions data in '.rtorrent-session'"
+	echo "and rtorrent's configuration file is '.rtorrent.rc', all in your home directory."
+	echo
+	echo "If you want to change configuration for rtorrent, such as download folder, port, etc.,"
+	echo "you will need to edit the '.rtorrent.rc' file. E.g. 'nano $HOMEDIR/.rtorrent.rc'${NORMAL}"
+	echo
+
+	# Ipv4 only
+	# grep 'inet6' instead of 'inet ' for ipv6
+	ip=$(ip addr | grep 'inet ' | awk '{print $2}' | cut -d/ -f1 | grep -v "127." | head -n 1)
+	if [ $ip ]; then
+		echo "Visit rutorrent at http://$ip/rutorrent"
+	else
+		echo "Visit rutorrent at http://IP-ADDRESS/rutorrent"
+	fi
+	echo
+}
+
+CHECK_ROOT
+LICENSE
+APACHE-UTILS
+rm -rf $TEMP_PLUGIN_DIR
+HEADER
+SET_RTORRENT_USER
+SET_WEB_USER
+
+# NOTICE: Change lib, rtorrent, rutorrent versions when update are available
+while true
+do
+	HEADER
+	echo " ${BOLD}rTorrent version: ${NORMAL}  ${RED}0.9.4${NORMAL}"
+	echo " ${BOLD}libTorrent version: ${NORMAL}${RED}0.13.4${NORMAL}"
+	echo " ${BOLD}ruTorrent version: ${NORMAL} ${RED}3.6${NORMAL}"
+	echo
+	echo " ${BOLD}rTorrent user: ${NORMAL}${GREEN}$RTORRENT_USER${NORMAL}"
+	echo
+	echo -n " ${BOLD}ruTorrent user(s): ${NORMAL}${GREEN}"
+	LIST_WEB_USERS
+	echo " ${NORMAL}${BOLD}ruTorrent plugins: ${NORMAL}${GREEN}"
+	LIST_PLUGINS
+	echo
+	echo " ${NORMAL}[1] - Change rTorrent user"
+	echo " [2] - Add another ruTorrent user"
+	echo " [3] - Download plugins"
+	echo
+	echo " [0] - Start installation"
+	echo " [q] - Quit"
+	echo
+	echo -n "${GREEN}>>${NORMAL} "
+	read case
+
+	case "$case" in
+		1) 	SET_RTORRENT_USER
+			;;
+		2) 	SET_WEB_USER
+			;;
+		3) 	SELECT_PLUGINS
+			;;
+		0)	APT-DEPENDENCIES
+			INSTALL_RTORRENT
+			INSTALL_RUTORRENT
+			CONFIGURE_APACHE
+			SETUP_INIT
+			INSTALL_COMPLETE
+			break
+			;;
+		q)	break
+			;;
+	esac
+done


### PR DESCRIPTION
Changed some words and re-formatted the entire file (spaces, etc)
Removed "apache2-utils" from APT-DEPENDENCIES function, cause is already installed in APACHE-UTILS function
Added raspberrypi logo, thanks to piksel https://gist.github.com/piksel/3023588
Added recommended plugins
Added a exit choise

Working with Raspbian Wheezy