### PR TITLE
Adding an option "All Plugins"

### DIFF
--- a/Rtorrent-Auto-Install-3.0.2-Debian-Wheezy
+++ b/Rtorrent-Auto-Install-3.0.2-Debian-Wheezy
@@ -237,6 +237,7 @@ function SELECT_PLUGINS {
 		echo "45 - Noty v3.6"
 		echo "46 - Task v3.6"
 		echo "47 - All Plugins v3.6. More at https://github.com/Novik/ruTorrent/wiki/Plugins"
+		echo "48 - Install all plugins"
 		echo
 		echo "0 - Exit plugin installation"
 		echo
@@ -512,6 +513,7 @@ function SELECT_PLUGINS {
 			;;
 
 			29)
+			#Remember to update option 48 "All plugins"
 			name="NFO Plugin"
 			url="http://srious.biz/nfo.tar.gz"
 			file="nfo.tar.gz"
@@ -521,6 +523,7 @@ function SELECT_PLUGINS {
 			;;
 
 			30)
+			#Remember to update option 48 "All plugins"
 			name="Chat Plugin v2.0"
 			url="http://rutorrent-chat.googlecode.com/files/chat-2.0.tar.gz"
 			file="chat-2.0.tar.gz"
@@ -530,6 +533,7 @@ function SELECT_PLUGINS {
 			;;
 
 			31)
+			#Remember to update option 48 "All plugins"
 			name="Logoff Plugin v1.3"
 			url="http://rutorrent-logoff.googlecode.com/files/logoff-1.3.tar.gz"
 			file="logoff-1.3.tar.gz"
@@ -539,6 +543,7 @@ function SELECT_PLUGINS {
 			;;
 
 			32)
+			#Remember to update option 48 "All plugins"
 			name="Pause Plugin v1.2"
 			url="http://rutorrent-pausewebui.googlecode.com/files/pausewebui.1.2.zip"
 			file="pausewebui.1.2.zip"
@@ -548,6 +553,7 @@ function SELECT_PLUGINS {
 			;;
 
 			33)
+			#Remember to update option 48 "All plugins"
 			name="Instant Search Plugin v1.0"
 			url="http://rutorrent-instantsearch.googlecode.com/files/instantsearch.1.0.zip"
 			file="instantsearch.1.0.zip"
@@ -682,6 +688,7 @@ function SELECT_PLUGINS {
 			;;
 
 			47)
+			#Remember to update option 48 "All plugins"
 			name="Plugins v3.6"
 			url="http://dl.bintray.com/novik65/generic/plugins-3.6.tar.gz"
 			file="plugins-3.6.tar.gz"
@@ -691,7 +698,63 @@ function SELECT_PLUGINS {
 			mv /tmp/plugins/* $TEMP_PLUGIN_DIR
 			apt-get -y install php5-geoip ffmpeg curl libzen0 libmediainfo0 mediainfo unrar-free
 			;;
+			
+			48)
+			#Note : the $unpacks are not necessery, it is only here to indicate where to put the $file in the custom DOWNLOAD_FUNCTION
+			name="All Plugins"
+			desc="This installs all plugins, those included in Plugins v3.6 and those that were not."
+			#Plugins
+			url1="http://dl.bintray.com/novik65/generic/plugins-3.6.tar.gz"
+			file1="plugins-3.6.tar.gz"
+			#unpack="tar -zxvf $file -C /tmp/"
+			#NFO Plugin
+			url2="http://srious.biz/nfo.tar.gz"
+			file2="nfo.tar.gz"
+			#unpack="tar -zxvf $file2 -C $TEMP_PLUGIN_DIR"
+			#Chat Plugin
+			url3="http://rutorrent-chat.googlecode.com/files/chat-2.0.tar.gz"
+			file3="chat-2.0.tar.gz"
+			#unpack="tar -zxvf $file3 -C $TEMP_PLUGIN_DIR"
+			#Logoff Plugin
+			url4="http://rutorrent-logoff.googlecode.com/files/logoff-1.3.tar.gz"
+			file4="logoff-1.3.tar.gz"
+			#unpack="tar -zxvf $file4 -C $TEMP_PLUGIN_DIR"
+			#Pause Plugin
+			url5="http://rutorrent-pausewebui.googlecode.com/files/pausewebui.1.2.zip"
+			file5="pausewebui.1.2.zip"
+			#unpack="unzip $file5 -d $TEMP_PLUGIN_DIR"
+			#Search Plugin
+			url6="http://rutorrent-instantsearch.googlecode.com/files/instantsearch.1.0.zip"
+			file6="instantsearch.1.0.zip"
+			#unpack="unzip $file6 -d $TEMP_PLUGIN_DIR"
+			
+			# This is a custom function of DOWNLOAD_PLUGIN. Putting it here make it more easy to update and maintain it than at the top.
+			echo
+			echo -e "$desc"
+			echo
+			read -p "Download '$name'. [y/n]: " -n 1
 
+			if [[ $REPLY =~ [Yy]$ ]]; then
+				echo
+				wget $url1 $url2 $url3 $url4 $url5 $url6
+				tar -zxvf $file1 -C /tmp/
+				tar -zxvf $file2 $file3 $file4 -C $TEMP_PLUGIN_DIR
+				unzip $file5 $file6 -d $TEMP_PLUGIN_DIR
+				
+				if [ $? -eq "0" ]; then
+					rm $file1 $file2 $file3 $file4 $file5 $file6
+					echo
+					PLUGIN_ARRAY+=("${name}")
+					error1="${GREEN}'$name' downloaded, unpacked and moved to temporary plugins folder${NORMAL}"					else
+					echo
+					error1="${RED}Something went wrong.. Error!${NORMAL}"
+				fi
+			fi
+			echo
+			mv /tmp/plugins/* $TEMP_PLUGIN_DIR
+			apt-get -y install php5-geoip ffmpeg curl libzen0 libmediainfo0 mediainfo unrar-free
+			;;
+			
 			0)
 			break
 			;;


### PR DESCRIPTION
Hello,

I've been working on adding another option for the plugins to install all of them instead of downloading them one by one. I couldn't use the existing DOWNLOAD_PLUGIN because the script has to unzip and untar different type of files to different location and I couldn't make it work, so I just did a custom DOWNLOAD_PLUGIN for the moment.

My idea is to merge all of the url{1-6} into one to make it work with the existing DOWNLOAD_PLUGIN function to make it cleaner, for exemple url="$url1 $url2 $url3 $url4 $url5 $url6". This work for $url and $file but doesn't work for $unpack.

I tried unpack="tar -zxvf $file1 -C /tmp/ && tar -zxvf $file2 $file3 $file4 -C $TEMP_PLUGIN_DIR && unzip $file5 $file6 -d $TEMP_PLUGIN_DIR" but it doesn't work. Any idea?

I try to make it look like that :

                       ...
                        #Search Plugin
			url6="http://rutorrent-instantsearch.googlecode.com/files/instantsearch.1.0.zip"
			file6="instantsearch.1.0.zip"
			#unpack="unzip $file6 -d $TEMP_PLUGIN_DIR"
			
			url="$url1 $url2 $url3 $url4 $url5 $url6"
			file="$file1 $file2 $file4 $file4 $file5 $file6"
                        unpack="suggestion needed"
			DOWNLOAD_PLUGIN
			mv /tmp/plugins/* $TEMP_PLUGIN_DIR
			apt-get -y install php5-geoip ffmpeg curl libzen0 libmediainfo0 mediainfo unrar-free
			;;
			...

I didn't not properly tested it, I'm just making a pull request to have suggestion, it should not be (yet at least) merge.