### PR TITLE
minor changes

### DIFF
--- a/Rtorrent-Auto-Install-3.0.2-Debian-Wheezy
+++ b/Rtorrent-Auto-Install-3.0.2-Debian-Wheezy
@@ -48,6 +48,7 @@ function APACHE_UTILS {
 		read -p " Do you want to install it? [y/n] " -n 1
 		if [[ $REPLY =~ [Yy]$ ]]; then
 			clear
+			apt-get update
 			apt-get -y install apache2-utils unzip
 		else
 			clear


### PR DESCRIPTION
On a fresh install, the script fails to install "apache2-utils" and "unzip" without updating the packages list first.