### PR TITLE
set new default plugins dir

### DIFF
--- a/Plugins-installer-script-3.1.1
+++ b/Plugins-installer-script-3.1.1
@@ -33,11 +33,11 @@ function CHECK_ROOT {
 # Function to check or change your plugins folders
 function CHECK_PLUGINS_FOLDER {
 	echo " Please enter the path to your rutorrent plugins folder."
-	echo -n " Leave blank for default [/var/www/rutorrent/plugins]: "
+	echo -n " Leave blank for default [/var/www/html/rutorrent/plugins]: "
 	read DIR
 
 	if [[ -z "$DIR" ]]; then
-		PLUGINS_DIR="/var/www/rutorrent/plugins"
+		PLUGINS_DIR="/var/www/html/rutorrent/plugins"
 	else
 		count=0
 		while [ $count -eq 0 ]; do


### PR DESCRIPTION
I ran Rtorrent-Auto-Install-3.0.2-Debian-Jessie which installed rtorrent, apache and rutorrent just fine.
Plugin install seems to be broken tho.

Good to know there is a separate script for the plugins :)

This fix sets new default plugin directory path in plugin script.